### PR TITLE
on reveal ready: remove inert from current slide

### DIFF
--- a/resource/decker/support/plugins/a11y/a11y.js
+++ b/resource/decker/support/plugins/a11y/a11y.js
@@ -8,7 +8,6 @@ let Reveal;
 /**
  * Adds inert to all inactive slides and adds an on-slidechanged callback to reveal
  * to toggle inert on the slides changed.
- * TODO: Figure out if we want to have this instead of a viewDistance of 1.
  * This might cause performance issues on more complex DOM trees but they have yet to be observed.
  * As such this function is - for now - just "here" for future reference.
  */
@@ -16,6 +15,11 @@ function fixTabsByInert() {
   let slides = document.querySelectorAll("section");
   slides.forEach((slide) => {
     slide.inert = true;
+  });
+  Reveal.on("ready", (event) => {
+    if (event && event.currentSlide) {
+      event.currentSlide.inert = false;
+    }
   });
   Reveal.on("slidechanged", (event) => {
     if (event.previousSlide) {


### PR DESCRIPTION
Fix for issue #12 

If and only if the presentation started and stayed on the title slide the onslidechanged that is supposed to remove the intertness of the current slide was not triggered. This now happens on reveal's ready event on the current slide in any case which should fix the whiteboard not working on the first slide of a presentation. (refreshing the page on any other slide or entering the presentation on any other slide causes reveal to trigger an onslidechange event thus hiding this error very well behind our own mechanisms)