### PR TITLE
Hotfix Windows + Linux Decker 13 nwburg template

### DIFF
--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -34,9 +34,12 @@ if (-Not $skiptemplates) {
 <# Cleanup of old files #> 
 Write-Host "Cleaning before new build" -ForegroundColor Green
 & stack clean
-Remove-Item "$deckerdir\resource\decker\support\vendor" -Recurse -Force -ErrorAction Continue
-Remove-Item "$deckerdir\public" -Recurse -Force -ErrorAction Ignore 
-
+if (test-path "$deckerdir\resource\decker\support\vendor") {
+    Remove-Item "$deckerdir\resource\decker\support\vendor" -Recurse -Force -ErrorAction Continue
+}
+if (test-path "$deckerdir\public"){
+    Remove-Item "$deckerdir\public" -Recurse -Force -ErrorAction Ignore 
+}
 
 
 Write-Host "Starting build of standalone binary" -ForegroundColor Green

--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@ local-bin-path := $(HOME)/.local/bin
 
 decker-name := $(base-name)-$(version)-$(branch)-$(commit)
 
+.PHONY: build clean test install list dist docs resource-zip css
 
 build: 
 	stack build -j8
@@ -87,5 +88,5 @@ clean-recordings:
 	rm -f test/decks/*-recording*
 	rm -f test/decks/*-times.json
 	rm -f test/decks/*-annot.json
-
-.PHONY: build clean test install dist docs resource-zip css
+list:
+	@LC_ALL=C $(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\n)# Files(\n|$$)/,/(^|\n)# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ A markdown based tool for slide deck creation.
 
 Note:
 
-Decker will be installed under `~/.local/bin` which is not recognized by your terminal (zsh)
+Decker will be installed under `~/.local/bin` which is default not recognized by your terminal.
 If decker is not found by your terminal, add the path to the corresponding config file. 
 For zsh (default for macos) do the following steps. Run from the terminal:
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,14 @@ session!
 
 `$Env:Path += ";${Env:ProgramFiles(x86)}\Decker\bin"`
 
+### Note:
+
+Windows Antivirus Protection has a high impact on compilation time. Add the following directories as exclusions to safe about 20-40% compilation time.
+
+- Haskell stack build tool: usually under `C:\sr`
+- Haskell compiler: `%AppData%\Local\Programs\stack\x86_64-windows\ghc-x.x.x\bin`
+- this repository
+
 ## Development
 
 ### Haskell

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,16 @@ A markdown based tool for slide deck creation.
 4.  `git submodule update --init --recursive`
 5.  `make install`
 
+Note:
+
+Decker will be installed under `~/.local/bin` which is not recognized by your terminal (zsh)
+If decker is not found by your terminal, add the path to the corresponding config file. 
+For zsh (default for macos) do the following steps. Run from the terminal:
+
+1.  `touch ~/.zshrc`
+2.  `echo PATH=$HOME/.local/bin:$PATH > ~/.zshrc`
+3.  `source ~/.zshrc`
+
 ## Installation from source on Windows
 
 Instead of a `makefile` we use a PowerShell script on Windows to install decker

--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,8 @@ document, depending on the file name.
     Publish the generated files to a remote location using `rsync` if the
     location is specified in the meta data. The keys `rsync-destination.host`
     and `rsync-destination.path` specify the publishing destination.
+    
+    Note: openssh Server do not work properly with rsync for Windows. Use cygwin and its terminal to perform decker publish.
 
 ## Contributions
 

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Use [Ubuntu's Advanced Packaging Tool
 tools.
 
 ``` sh
-apt-get update && apt-get install -y gnuplot graphviz libbz2-dev pdf2svg rsync ssh      
+apt-get update && apt-get install -y gnuplot graphviz libbz2-dev pdf2svg rsync ssh libtinfo-dev    
 ```
 
 To confirm that you have installed all of the required external tools, run the

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,8 @@ the full functionality:
 -   [*ssh*](https://www.openssh.com) for publishing slide decks and resources
 -   [*rsync*](http://formulae.brew.sh/repos/Homebrew/homebrew-core/formula/rsync)
     for publishing slide decks and resources
+    - Note: openssh Server do not work properly with rsync for Windows. Use cygwin and its terminal to perform decker publish.
+
 -   [*LaTeX* with pdflatex](https://www.latex-project.org) to generate LaTeX in
     PDF-files and embedded Tikz figures
 -   [*Graphviz*](http://graphviz.org) to generate graphs using `dot`
@@ -209,9 +211,7 @@ document, depending on the file name.
     Publish the generated files to a remote location using `rsync` if the
     location is specified in the meta data. The keys `rsync-destination.host`
     and `rsync-destination.path` specify the publishing destination.
-    
-    Note: openssh Server do not work properly with rsync for Windows. Use cygwin and its terminal to perform decker publish.
-
+   
 ## Contributions
 
 ### Pull requests

--- a/resource/nwburg/template/deck.html
+++ b/resource/nwburg/template/deck.html
@@ -216,7 +216,14 @@ $endif$
       ]
     };
 
-    console.log(3);
+    Reveal.initialize(revealConfig);
+
+    /* Highlight JS tries to highlight assembly code within the lecture. 
+    ATM if tries to interpret more than just the assembly code on the slides, 
+    replacing part of latex instructions and thus decker fails to compile. 
+    We do have to fix this before adding it back to the release
+     
+     console.log(3);
     Reveal.initialize(revealConfig).then(() => {
     const hljs = highlightPlugin().hljs;
 
@@ -258,7 +265,7 @@ $endif$
       Array.from(Reveal.getRevealElement().querySelectorAll('pre code')).forEach((block) => {
          highlightPlugin().highlightBlock(block);
     });
-   });
+   }); */
 
     window.Reveal = Reveal;
   </script>

--- a/resource/nwburg/template/deck.html
+++ b/resource/nwburg/template/deck.html
@@ -218,54 +218,13 @@ $endif$
 
     Reveal.initialize(revealConfig);
 
-    /* Highlight JS tries to highlight assembly code within the lecture. 
+    /* TODO: Highlight JS tries to highlight assembly code within the lecture. 
     ATM if tries to interpret more than just the assembly code on the slides, 
-    replacing part of latex instructions and thus decker fails to compile. 
-    We do have to fix this before adding it back to the release
-     
-     console.log(3);
-    Reveal.initialize(revealConfig).then(() => {
-    const hljs = highlightPlugin().hljs;
-
-    // Here you can call functions on hljs, e.g. registerLanguage and configure
-    hljs => hljs.registerLanguage(
-            "asm6502acme",
-            (() => {
-               "use strict";
-               return (r) => ({
-                  name: "asm6502acme",
-                  case_insensitive: true,
-                  keywords: {
-                           keyword:
-                        "ADC AND ASL BCC BCS BEQ BIT BMI BNE BPL BRK BVC BVS CLC CLD CLI CLV CMP CPX CPY DEC DEX DEY EOR INC INX INY JMP JSR LDA LDX LDY LSR NOP ORA PHA PHP PLA PLP ROL ROR RTI RTS SBC SEC SED SEI STA STX STY TAX TAY TSX TXA TXS TYA",
-                     built_in: "x|0 y|0",
-                     symbol:
-                        "scr by byte txt pet to source binary initmem wo word hex h align fi fill skip convtab ct text tx raw scrxor zone sl if ifdef ifndef for set do while endoffile warn error serious macro pseudopc cpu to al as rl rs",
-                  },
-                  contains: [
-                     r.COMMENT(";", "$", { relevance: 0 }),
-                     {
-                     className: "number",
-                     begin:
-                        "(-?)(\\$[a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",
-                     },
-                     r.QUOTE_STRING_MODE,
-                     {
-                     className: "string",
-                     begin: "'",
-                     end: "[^\\\\]'",
-                     illegal: "[^\\\\][^']",
-                     },
-                     { className: "symbol", begin: "^![A-Za-z0-9_.$]+:" },
-                  ],
-               });
-            })()
-         );
-      // Run the plugin's highlighting code that was skipped on load
-      Array.from(Reveal.getRevealElement().querySelectorAll('pre code')).forEach((block) => {
-         highlightPlugin().highlightBlock(block);
-    });
-   }); */
+    and thus decker fails to compile. 
+    We do have to fix this before adding it back to a release. 
+    See commit 565e6b1 for original source. For some reason, comment the responsible
+    code section does not work. Neither client /server side html nor js comment. 
+    It is still interpreted. Therefore the code has been removed */
 
     window.Reveal = Reveal;
   </script>


### PR DESCRIPTION
Hey
I tried the Decker 13 RC3 and it still does not work for me on Linux and Windows using the nwburg template.
The problem seems to be highlight.js interfering with the md compilation. Thus, the problematic section in the template has been replaced with a Todo. Commenting the section did not help. Whatever block comments were used, the js code in the script tag was always interpreted. Hopefully you know better how to do that properly.

Oh and I removed the annoying "no resource found" error message on the clean up step of the compilation by testing the existence.