### PR TITLE
Prefer current tab in explain.js video recording

### DIFF
--- a/resource/decker/support/plugins/explain/explain.js
+++ b/resource/decker/support/plugins/explain/explain.js
@@ -317,6 +317,7 @@ async function captureScreen() {
       resizeMode: "crop-and-scale",
     },
     audio: true,
+    preferCurrentTab: true,
   });
 
   let video = desktopStream.getVideoTracks()[0].getSettings();


### PR DESCRIPTION
In current versions of chrome, the current tab did not show up at all in the tab list on my machine (MacOS).
Additionally, it was always annoying to search through the list if many tabs were opened.
A recent chrome feature makes this selection much easier by setting `preferCurrentTab`.

https://chromestatus.com/feature/5045313003847680

According to
https://groups.google.com/a/chromium.org/g/blink-dev/c/YoefXLTQsw0/m/NVoV6NcIAgAJ , this does not cause issues in Gecko and Webkit (however I did not try).