### PR TITLE
Make quiz-ic placeholder configurable and make it an actual placeholder that is itself not selectable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -142,7 +142,10 @@ to:
     -   Show the whiteboard button.
     -   Start a quiz session with the quiz server, if configured.
 
--   Panndocs footnotes are now rendered at the end of the slide, wrapped in a
+-   Pandocs footnotes are now rendered at the end of the slide, wrapped in a
     DIV with class `footnotes`.
+
+-   `quiz-ic`'s selection boxes now have proper placeholders whose content can be
+    configured by the `quiz.ic.placeholder` config variable.
 
 -   Many, many bugs have been fixed all around.

--- a/resource/tudo/template/default.yaml
+++ b/resource/tudo/template/default.yaml
@@ -91,6 +91,10 @@ dictionary:
       qmi-drop-hint: ...and put them here into the correct category.
       solution-button: Show Solution
 
+quiz:
+  ic:
+    placeholder: 'Antwort auswählen ...'
+
 palette:
   contrast: 0.40
   colors:

--- a/src/Text/Decker/Filter/Quiz.hs
+++ b/src/Text/Decker/Filter/Quiz.hs
@@ -292,7 +292,7 @@ renderInsertChoices meta quiz@(InsertChoices title tgs qm q) =
     select :: [Choice] -> Inline
     select choices =
       tag "select" $ Span ("", [], []) (defaultOpt : map options choices)
-    defaultOpt = tag "option" $ Span ("", ["wrong"], []) [Str "..."]
+    defaultOpt = tag "option" $ Span ("", ["wrong"], [("hidden", ""), ("disabled", ""), ("selected", "")]) [Str $ lookupMetaOrElse "..." "quiz.ic.placeholder" meta]
     options :: Choice -> Inline
     options (Choice correct text comment) =
       tag "option" $ Span ("", [ocls], [("value",stringify text)]) text


### PR DESCRIPTION
This should keep the default value we are used to but makes the value configurable if desired. Also makes it a placeholder value that is not within the list of selectable answers once interacted with. Please check if this breaks anyhting, on my end everything seems to work.