### PR TITLE
move nwburg template back to pandoc instead of highlightjs linting

### DIFF
--- a/resource/nwburg/support/css/wburg.css
+++ b/resource/nwburg/support/css/wburg.css
@@ -642,7 +642,7 @@ div.block.theorem {
  }
  
  .reveal [class*="quiz-"] .show-right {
-   background-color: var(--green-background-color); */
+   background-color: var(--green-background-color);
    border-color: var(--green-border-color);
  }
  

--- a/resource/nwburg/template/deck.html
+++ b/resource/nwburg/template/deck.html
@@ -185,7 +185,6 @@ $endif$
       explain: Decker.meta.explain,
       feedback: Decker.meta.feedback || Decker.meta["decker-engine"],
       jingles: Decker.meta.jingles,
-      highlight: { highlightOnLoad: false },
       // list of plugins
       plugins: [
          deckerPlugin,
@@ -217,14 +216,6 @@ $endif$
     };
 
     Reveal.initialize(revealConfig);
-
-    /* TODO: Highlight JS tries to highlight assembly code within the lecture. 
-    ATM if tries to interpret more than just the assembly code on the slides, 
-    and thus decker fails to compile. 
-    We do have to fix this before adding it back to a release. 
-    See commit 565e6b1 for original source. For some reason, comment the responsible
-    code section does not work. Neither client /server side html nor js comment. 
-    It is still interpreted. Therefore the code has been removed */
 
     window.Reveal = Reveal;
   </script>


### PR DESCRIPTION
After talking to @marcerich  we will adopt the Pandoc Syntax Highlighting test deck for code highlighting with the nwburg template.
Thus we do not need the buggy code section. I need the modifications to the template so that others in Würzburg can improve  on the styling. Would you please merge them?
Best,
Matthias