### PR TITLE
Don't rsync --delete in Haskell, instead rely on configuration files

### DIFF
--- a/src/Text/Decker/Internal/External.hs
+++ b/src/Text/Decker/Internal/External.hs
@@ -59,7 +59,7 @@ programs =
       ExternalProgram
         -- []
         "rsync"
-        [ "--recursive", "--copy-links", "--delete" ]
+        [ "--recursive", "--copy-links" ]
         ["--version"]
         (helpText "`rsync` (https://rsync.samba.org)")
     ),


### PR DESCRIPTION
The --delete option should be chosen by the user via decker.yaml.