### PR TITLE
LaTeX Textsizes and Scaling

### DIFF
--- a/resource/decker/support/css/deck.css
+++ b/resource/decker/support/css/deck.css
@@ -8,6 +8,8 @@ Margins, colors, fonts and stuff should be defined here. */
 @import url("./structure.css");
 @import url("./style.css");
 @import url("./media.css");
+@import url("./text.css");
+@import url("./scaling.css");
 
 /* Box sizing is much nicer for calculations. */
 body.deck {

--- a/resource/decker/support/css/scaling.css
+++ b/resource/decker/support/css/scaling.css
@@ -1,0 +1,16 @@
+[scale] {
+  width: fit-content;
+  height: fit-content;
+}
+
+.fullpage {
+  width: var(--slide-width);
+}
+
+.halfpage {
+  width: calc(0.5 * var(--slide-width));
+}
+
+.center-content > * {
+  margin: auto;
+}

--- a/resource/decker/support/css/text.css
+++ b/resource/decker/support/css/text.css
@@ -1,0 +1,51 @@
+/***********************************
+Classes for sizing and coloring Text
+************************************/
+
+.miniscule {
+  font-size: 0.333em;
+}
+
+.tiny {
+  font-size: 0.5em;
+}
+
+.scriptsize {
+  font-size: 0.6em;
+}
+
+.footnotesize {
+  font-size: 0.7em;
+}
+
+.small {
+  font-size: 0.8em;
+}
+
+.normalsize {
+  font-size: 1em;
+}
+
+.large {
+  font-size: 1.25em;
+}
+
+.Large {
+  font-size: 1.5em;
+}
+
+.LARGE {
+  font-size: 1.75em;
+}
+
+.huge {
+  font-size: 2em;
+}
+
+.Huge {
+  font-size: 2.5em;
+}
+
+.HUGE {
+  font-size: 3em;
+}

--- a/resource/decker/support/plugins/decker/decker.js
+++ b/resource/decker/support/plugins/decker/decker.js
@@ -31,6 +31,13 @@ function onStart(deck) {
   });
 }
 
+/**
+ * This needs to be called on a slidechange because an element that is not yet visible
+ * (doing the adjustment on page load) has a bounding box of size (0,0).
+ *
+ * @param {*} deck
+ * @param {*} slide
+ */
 function adjustScaleElements(deck, slide) {
   const slides = deck.getSlidesElement();
   const transform = slides.style.transform;

--- a/resource/tudo/support/css/tudo-deck.css
+++ b/resource/tudo/support/css/tudo-deck.css
@@ -5,6 +5,11 @@
  * GLOBAL STYLES
  *********************************************/
 
+::selection {
+  color: var(--background-color);
+  background-color: var(--accent5);
+}
+
 body {
   background: var(--background-color);
   font-family: "Lato", sans-serif;
@@ -90,18 +95,6 @@ div.block {
 /*********************************************
  * font sizes and styles
  *********************************************/
-
-.reveal .tiny {
-  font-size: 0.5em;
-}
-
-.reveal .small {
-  font-size: 0.7em;
-}
-
-.reveal .large {
-  font-size: 1.2em;
-}
 
 del {
   color: var(--accent0);

--- a/test/decks/text-styling-deck.md
+++ b/test/decks/text-styling-deck.md
@@ -1,0 +1,149 @@
+---
+title: Text Size Test Deck
+---
+
+# LaTeX-esque Font Sizes:
+
+::: columns-1-1
+
+::: {}
+
+- [miniscule]{.miniscule}
+- [tiny]{.tiny}
+- [scriptsize]{.scriptsize}
+- [footnotesize]{.footnotesize}
+- [small]{.small}
+- [normalsize]{.normalsize}
+- [large]{.large}
+
+:::
+
+::: {}
+
+- [Large]{.Large}
+- [LARGE]{.LARGE}
+- [huge]{.huge}
+- [Huge]{.Huge}
+- [HUGE]{.HUGE}
+
+:::
+
+:::
+
+# Text Color
+
+- [accent0]{.accent0}
+- [accent1]{.accent1}
+- [accent2]{.accent2}
+- [accent3]{.accent3}
+- [accent4]{.accent4}
+- [accent5]{.accent5}
+- [accent6]{.accent6}
+- [accent7]{.accent7}
+
+# Text Shade
+
+- [shade0]{.shade0}
+- [shade1]{.shade1}
+- [shade2]{.shade2}
+- [shade3]{.shade3}
+- [shade4]{.shade4}
+- [shade5]{.shade5}
+- [shade6]{.shade6}
+- [shade7]{.shade7}
+
+# Normal sizes to compare to
+
+::: dummy
+
+| Table | Table | Table |
+| :---: | :---: | :---: |
+| What  | What  | What  |
+
+:::
+
+There is some text that wants to be scaled up.
+
+# Scaled with CSS: transform
+
+::: {style='transform: scale(2); transform-origin: "top"'}
+
+| Table | Table | Table |
+| :---: | :---: | :---: |
+| What  | What  | What  |
+
+:::
+
+There is some text that wants to be [scaled up]{style='display: inline-block; transform: scale(2); transform-origin: "left"'}.
+
+# Scaled with Scalebox-Mechanism
+
+::: {scale=2}
+
+| Table | Table | Table |
+| :---: | :---: | :---: |
+| What  | What  | What  |
+
+:::
+
+There is some text that wants to be [scaled up]{scale=2}.
+
+# It needs some tricks to properly recenter content
+
+::: {.center-content}
+
+::: {scale=2}
+
+| Table | Table | Table |
+| :---: | :---: | :---: |
+| What  | What  | What  |
+
+:::
+
+:::
+
+There is some text that wants to be [scaled up]{scale=2}.
+
+# Explanation of the mechanism {.sub}
+
+Take any element with the scale attribute and take its `clientBoundingBox`.
+
+From the box take width and height and divide it by the current slide scale to get its original width and height.
+
+Scale up the original width and height by the scale factor.
+
+Create a wrapper object with the scaled up width and height of the element.
+
+Add the actual `transform: scale(x)` on the element. Because the wrapper has the size of the element after transformation it reflows and rearranges all elements on the slide.
+
+# Scaled with font-size
+
+::: {.huge}
+
+| Table | Table | Table |
+| :---: | :---: | :---: |
+| What  | What  | What  |
+
+:::
+
+There is some text that wants to be [scaled up]{.huge}.
+
+# Width relative to page size 
+
+::: {.fullpage .block .accent3}
+
+Class: .fullpage
+
+:::
+
+::: {.halfpage .block .accent3}
+
+Class: .halfpage
+
+:::
+
+::: {width="calc(var(--slide-width) * 0.75)" .block .accent3}
+
+`width="calc(var(--slide-width) * 0.75)"`
+
+:::


### PR DESCRIPTION
This merge adds a chunk of classes that are equal to the names of LaTeX Font Size modifying environments to the default css ruleset. These shrink or enlarge the font size of the object they are attached to:

```
[Large Text]{.large}

::: LARGE

Larger Text

:::
```

In addition it adds a mechanism that allows a user to "scale" any DOM element:

```
::: {scale=2}

Content

:::
```

Because in HTML, using the transform scale mechanism does not scale the DOM element's bounding box, a wrapping mechanism is used to put a DOM element in place that has the exact size of the inner, scaled element. Thus the rest of the page's content is adjusted in a similar way LaTeX's scalebox does its thing.

Please review if the later mechanism is even desirable. Documentation about the mechanism is in the new test-deck.