### PR TITLE
Add stylesheet link in nwburg template deck.html

### DIFF
--- a/resource/nwburg/template/deck.html
+++ b/resource/nwburg/template/deck.html
@@ -31,6 +31,7 @@ $endif$
   <!-- Default values for CSS variables can live here. They can be overridden by
   meta data values. -->
   <link rel="stylesheet" href="$decker-support-dir$/css/variables.css">
+  <link rel="stylesheet" href="support/css/wburg.css">
 
   <!-- Transfer meta data values from keys `palette.colors` and `css-variables`
   into a style sheet. Default values can come from `variables.css`. -->


### PR DESCRIPTION
In response to issue #105 - add a link to the default wurzburg css file.