### PR TITLE
fix #117 by changing move operations

### DIFF
--- a/src/Text/Decker/Filter/Media.hs
+++ b/src/Text/Decker/Filter/Media.hs
@@ -214,7 +214,8 @@ compileCodeBlock attr@(id, classes, _) code caption = do
                 createDirectoryIfMissing True (takeDirectory path)
                 tmp <- uniqueTransientFileName path
                 Text.writeFile tmp code
-                renameFile tmp path
+                copyFile tmp path
+                removeFile tmp
                 putStrLn $ "# write (" <> path <> ")"
           )
       uri <- lift $ URI.mkURI (toText path)

--- a/src/Text/Decker/Server/Video.hs
+++ b/src/Text/Decker/Server/Video.hs
@@ -83,7 +83,8 @@ convertVideoMp4 webm mp4 = do
       let args = ["-nostdin", "-v", "fatal", "-y", "-i", src, "-vcodec", "copy", "-acodec", "aac", tmp]
       putStrLn $ "# calling: ffmpeg " <> List.unwords args
       callProcess "ffmpeg" args
-      renameFile tmp dst
+      copyFile tmp dst
+      removeFile tmp
 
 -- | Converts a WEBM video file into an MP4 video file on the slow track. The audio is
 -- transcoded to AAC.
@@ -96,7 +97,8 @@ transcodeVideoMp4 webm mp4 = do
       let args = ["-nostdin", "-v", "fatal", "-y", "-i", src] <> slow <> [tmp]
       putStrLn $ "# calling: ffmpeg " <> List.unwords args
       callProcess "ffmpeg" args
-      renameFile tmp dst
+      copyFile tmp dst
+      removeFile tmp
 
 -- Transcoding parameters
 fast = ["-preset", "fast", "-vcodec", "copy"]
@@ -154,7 +156,8 @@ concatVideoMp4' ffmpegArgs listFile mp4 = do
               <> ["-acodec", "aac", tmp]
       putStrLn $ "# calling: ffmpeg " <> List.unwords args
       callProcess "ffmpeg" args
-      renameFile tmp dst
+      copyFile tmp dst
+      removeFile tmp
 
 -- | Atomically moves the transcoded upload into place.  All existing parts of
 -- previous uploads are removed.
@@ -164,7 +167,8 @@ replaceVideoUpload transcode upload webm = do
   mapM_ removeFile webms
   let mp4 = replaceExtension webm ".mp4"
   when transcode $ convertVideoMp4 upload mp4
-  renameFile upload webm
+  copyFile upload webm
+  removeFile upload
 
 -- | Appends the uploaded WEBM video to potentially already existing fragments.
 appendVideoUpload :: Bool -> FilePath -> FilePath -> IO ()


### PR DESCRIPTION
Changes renameFile of temporary files to a copyFile tmp path, followed by a removeFile. This now allows "moving" files across device borders as renameFile tends to fail when used. Using something like a tmpfs or simply having your working directory on a different mount than the /tmp/ directory causes renameFile to fail when decker tries to move generated files from the tmp directory to the workspace.

@flipreverse can confirm that this fixes this issue on his end

@monofon @mbotsch Can you two check if this creates any conflict inside your current workflow?