### PR TITLE
Licence appeared twice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -307,7 +307,3 @@ Server](https://github.com/haskell/haskell-language-server).
 ## License
 
 See [COPYING](./COPYING).
-
-## License
-
-See [COPYING](./COPYING).


### PR DESCRIPTION
The licence section appeared twice in the readme. Assumed that it was a copy paste error.