### PR TITLE
Added type conversion for whiteboard dimensions

### DIFF
--- a/resource/decker/support/plugins/whiteboard/whiteboard.js
+++ b/resource/decker/support/plugins/whiteboard/whiteboard.js
@@ -108,8 +108,8 @@ function readConfig() {
   ];
 
   // reveal setting wrt slide dimension
-  pageHeight = Reveal.getConfig().height;
-  pageWidth = Reveal.getConfig().width;
+  pageHeight = parseFloat(Reveal.getConfig().height);
+  pageWidth = parseFloat(Reveal.getConfig().width);
 
   // reveal elements
   slides = document.querySelector(".reveal .slides");


### PR DESCRIPTION
Due a yet unknown reason, the reveal dimensions read from config are strings instead of floats.
This *might* lead to a faulty behavior. When adding a new whiteboard page, the page height is added to current slide height. If the first is a string, both values are simply concatenated. This in turn leads to a *very* large page.
This fix converts width and height to floats when reading the config.