### PR TITLE
dev: Add support for NixOS dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+ENV_PRIVATE=.envrc.private
+if [ -f $ENV_PRIVATE ]; then
+    source_env $ENV_PRIVATE
+fi
+
+if [[ "$USE_NIX" = "true" ]]; then
+	use flake
+fi

--- a/.github/workflows/nix-check-setup.yml
+++ b/.github/workflows/nix-check-setup.yml
@@ -1,0 +1,31 @@
+name: Check and verify that building works on NixOS
+on:
+  push:
+permissions:
+  contents: read
+
+jobs:
+  nixos_verify:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out project
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: cachix/install-nix-action@v31
+    - uses: DeterminateSystems/magic-nix-cache-action@v13
+    - name: First check of nix flake
+      # catches syntax errors or misconfigurations of the flake on all systems
+      run: nix flake check --all-systems
+    - name: Try entering devshell
+      # causes exit code (=failure) if current system's artifact is unavailable
+      run: nix develop
+    - name: Install and setup direnv
+      run: |
+        sudo apt-get update && sudo apt-get install -y direnv
+        echo "export USE_NIX=true" > .envrc.private
+        direnv allow .
+        direnv export gha > "$GITHUB_ENV"
+    - name: Build project
+      run: |
+        make

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ index.md.generated
 third-party/chart.js/auto/package-lock.json
 third-party/chart.js/helpers/package-lock.json
 package-lock.json
+.direnv
+.envrc.private

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1759362264,
-        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -20,27 +20,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import inputs.systems;
+    perSystem = { config, self', inputs', pkgs, system, ... }: let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+      };
+    in {
+      devShells.default = pkgs.mkShell rec {
+        buildInputs = [
+          pkgs.stack
+          (pkgs.symlinkJoin {
+            name = "stack"; # will be available as the usual `stack` in terminal
+            paths = [ pkgs.stack ];
+            buildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/stack \
+                --add-flags "\
+                  --no-nix \
+                  --system-ghc \
+                  --no-install-ghc \
+                "
+            '';
+          })
+        ];
+      };
+    };
+  };
+}

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ decker-name := $(base-name)-$(version)-$(branch)-$(commit)
 .PHONY: build clean test install list dist docs css
 
 build: 
-	stack build -j8
+	ATTACH_RESOURCE_ZIP=1 stack build -j8
 
 clean-build: clean 
 	stack clean

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,4 +31,4 @@ nix:
     - pkg-config
     - bzip2
   path:
-    - "nixpkgs=https://github.com/NixOS/nixpkgs/archive/205fd4226592cc83fd4c0885a3e4c9c400efabb5.tar.gz"
+    - "nixpkgs=https://github.com/NixOS/nixpkgs/archive/b51242d7d43689db2f3be91bd05d5b24fbb469c4.tar.gz"

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,3 +20,15 @@ resolver: lts-20.26
 #   "$locals": -fhide-source-paths -Wno-missing-home-modules
 #   "$everything": -haddock
 
+nix:
+  enable: true
+  pure: true
+  packages:
+    - zlib
+    - cmake
+    - ninja
+    - libGLU
+    - pkg-config
+    - bzip2
+  path:
+    - "nixpkgs=https://github.com/NixOS/nixpkgs/archive/205fd4226592cc83fd4c0885a3e4c9c400efabb5.tar.gz"


### PR DESCRIPTION
Allows building the project on NixOS environments and fixes all (?) places where dependencies and external inputs are used.

Notes:
- to enable nix / load the flake, a `.envrc.private` containing `export USE_NIX=true` must be created, otherwise it's disabled by default
- a new workflow has been added accordingly, which checks whether the build on NixOS still succeeds as expected. It takes about 30 minutes to execute, as it builds all dependencies without cache, making sure that every workflow starts fresh and errors are caught the moment they are introduced.
- `stack.yaml` must also pin the nixpkgs version, as packages and the compiler are installed there instead of through the flake
- `makefile` has been fixed to also add `ATTACH_RESOURCE_ZIP=1` on the standard `build` target