### PR TITLE
copy images referenced in included HTML

### DIFF
--- a/src/Text/Decker/Filter/Decker2.hs
+++ b/src/Text/Decker/Filter/Decker2.hs
@@ -13,6 +13,7 @@ module Text.Decker.Filter.Decker2  where
 import Data.Map.Strict as Map
 import Relude
 import Text.Decker.Filter.Header
+import Text.Decker.Filter.HtmlResources
 import Text.Decker.Filter.Monad
 import Text.Decker.Filter.Util (oneImagePerLine, single)
 import Text.Decker.Internal.Common
@@ -102,6 +103,10 @@ mediaInlineListFilter inlines =
 
 -- | Match a single Block element
 mediaBlockFilter :: Block -> Filter Block
+-- Scan for resources if it's a RawBlock with HTML format
+mediaBlockFilter (RawBlock (Format "html") html) = do
+  newHtml <- scanHtmlResources html
+  return (RawBlock (Format "html") newHtml)
 -- A solitary image in a paragraph with a possible caption.
 mediaBlockFilter (Para [Image attr alt (url, title)])
   | unprocessed attr =
@@ -122,6 +127,10 @@ mediaBlockFilter block = return block
 
 -- | Matches a single Inline element
 mediaInlineFilter :: Inline -> Filter Inline
+-- Scan for resources if it's a RawInline with HTML format
+mediaInlineFilter (RawInline (Format "html") html) = do
+  newHtml <- scanHtmlResources html
+  return (RawInline (Format "html") newHtml)
 -- An inline image with a possible caption.
 mediaInlineFilter (Image attr alt (url, title))
   | unprocessed attr =

--- a/src/Text/Decker/Filter/HtmlResources.hs
+++ b/src/Text/Decker/Filter/HtmlResources.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Text.Decker.Filter.HtmlResources where
+
+import Relude
+import Text.HTML.TagSoup
+import Text.Decker.Filter.Monad
+import Text.Decker.Internal.Meta
+import Text.Decker.Internal.URI
+import Text.Decker.Filter.Local (transformUri)
+import Text.URI qualified as URI
+
+-- | Scans HTML text for image/media references, adds them to the resources list,
+-- and returns the HTML with adjusted paths.
+scanHtmlResources :: Text -> Filter Text
+scanHtmlResources html = do
+  let tags = parseTags html
+  transformedTags <- mapM transformTag tags
+  return $ renderTags transformedTags
+
+  where
+    transformTag :: Tag Text -> Filter (Tag Text)
+    transformTag (TagOpen name attrs) = do
+      newAttrs <- mapM (transformAttr name) attrs
+      return $ TagOpen name newAttrs
+    transformTag tag = return tag
+
+    transformAttr :: Text -> Attribute Text -> Filter (Attribute Text)
+    transformAttr tagName (attrName, attrValue)
+      | isPathAttr tagName attrName = do
+          uri <- URI.mkURI attrValue
+          -- Only transform local URIs to avoid breaking remote links
+          if not (isRemoteUri uri)
+            then do
+              turi <- transformUri uri ""
+              return (attrName, URI.render turi)
+            else return (attrName, attrValue)
+      | otherwise = return (attrName, attrValue)
+
+    -- Attributes that typically contain paths to assets
+    isPathAttr :: Text -> Text -> Bool
+    isPathAttr _ "src" = True
+    isPathAttr _ "href" = True
+    isPathAttr "link" "href" = True
+    isPathAttr "img" "src" = True
+    isPathAttr "video" "src" = True
+    isPathAttr "audio" "src" = True
+    isPathAttr "source" "src" = True
+    isPathAttr _ _ = False
+
+    isRemoteUri :: URI.URI -> Bool
+    isRemoteUri uri =
+      case URI.uriScheme uri of
+        Just s -> URI.unRText s `notElem` ["file", "public"]
+        Nothing -> URI.isPathAbsolute uri

--- a/src/Text/Decker/Filter/Local.hs
+++ b/src/Text/Decker/Filter/Local.hs
@@ -9,6 +9,8 @@ import Control.Monad.Catch
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import Relude
+import System.Directory (doesFileExist)
+import System.FilePath.Posix (dropDrive, (</>))
 import Text.Blaze.Html
 import Text.Blaze.Html.Renderer.Pretty qualified as Pretty
 import Text.Blaze.Html.Renderer.Text qualified as Text
@@ -268,12 +270,30 @@ transformUri uri ext = do
       if null (uriFilePath uri)
         then return uri
         else do
-          source <- addPathExtension ext uri
-          needFile $ targetFilePath source
-          targetUri base source
+          -- If the path is absolute, check if it exists in the project root.
+          -- If it doesn't exist on disk as a project asset, we assume it's 
+          -- intended to be a domain-absolute root URI (e.g. /site-logo.png).
+          let path = uriFilePath uri
+          isProjectAbsolute <- if isPathAbsoluteURI path
+            then do
+              exists <- liftIO $ doesFileExist (base </> dropDrive path)
+              return exists
+            else return True
+
+          if not isProjectAbsolute
+            then return uri
+            else do
+              source <- addPathExtension ext uri
+              needFile $ targetFilePath source
+              targetUri base source
     _ -> do
       modifyMeta (addMetaValue "decker.filter.links" (URI.render uri))
       return uri
+  where
+    isPathAbsoluteURI p = case p of
+      (x:_) -> x == '/'
+      [] -> False
+
 
 -- | Adds a remote URL to the `decker.filter.links` list in the meta data.
 processRemoteUri :: URI -> Filter URI

--- a/src/Text/Decker/Filter/Local.hs
+++ b/src/Text/Decker/Filter/Local.hs
@@ -15,6 +15,7 @@ import Text.Blaze.Html.Renderer.Text qualified as Text
 import Text.Blaze.Html5 qualified as H
 import Text.Blaze.Html5.Attributes qualified as A
 import Text.Blaze.Internal (Attributable)
+import Text.HTML.TagSoup
 import Text.Decker.Filter.Monad
 import Text.Decker.Internal.Meta
 import Text.Decker.Internal.URI


### PR DESCRIPTION
Generated with gemma4:31b, as I am not a Haskell expert. Not yet tested...

This would resolve one issue I still have with decker: sometimes HTML is just much more elegant to use than Markdown, when you have nested divs and inline styles and data-fragment (see, e.g., #142). But when you fall back to HTML, all the images need to be stored in the assets and have project relative path names, which does not match the development setup.

This patch is supposed to:
- copy images referenced from HTML tags into the output folders
- update paths in the HTML (but one man's poison is another man's medicine...)

The second patch make the path logic threefold:
- relative paths are relative to the source file
- absolute paths that match a file in the project folder are project-relative
- unmatched absolute paths remain absolute, to allow linking site-wide files (classic absolute paths)

That patch should be independent, maybe you'll want to make that configurable.